### PR TITLE
Avoid permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,13 +289,13 @@ Note: Android must dynamically obtain the READ_PHONE_STATE permission to judge 2
       //wifi
       case NetworkStatus.mobile2G:
       //2g
-      case NetworkStatus.moblie3G:
+      case NetworkStatus.mobile3G:
       //3g
-      case NetworkStatus.moblie4G:
+      case NetworkStatus.mobile4G:
       //4g
-      case NetworkStatus.moblie5G:
+      case NetworkStatus.mobile5G:
       //5h
-      case NetworkStatus.otherMoblie:
+      case NetworkStatus.othermobile:
       //other
     }
     setState(() {

--- a/android/src/main/kotlin/com/aledev/network_type_reachability/NetworkTypeReachabilityPlugin.kt
+++ b/android/src/main/kotlin/com/aledev/network_type_reachability/NetworkTypeReachabilityPlugin.kt
@@ -103,7 +103,7 @@ private  fun getNetworkState(connectivityManager: ConnectivityManager, context: 
     }
 
     if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-      return getMobileNetworkType(context)
+      return getMobileNetworkType(context, connectivityManager)
     }
   }else{
     val networkInfo = connectivityManager.activeNetworkInfo
@@ -116,7 +116,7 @@ private  fun getNetworkState(connectivityManager: ConnectivityManager, context: 
         return NetworkState.wifi.toString()
       }
       ConnectivityManager.TYPE_MOBILE,ConnectivityManager.TYPE_MOBILE_DUN,ConnectivityManager.TYPE_MOBILE_HIPRI -> {
-        return getMobileNetworkType(context)
+        return getMobileNetworkType(context, connectivityManager)
       }
       else -> return NetworkState.unReachable.toString()
     }
@@ -125,18 +125,15 @@ private  fun getNetworkState(connectivityManager: ConnectivityManager, context: 
 }
 
 @RequiresApi(Build.VERSION_CODES.N)
-private  fun getMobileNetworkType(context: Context): String {
+private  fun getMobileNetworkType(context: Context, connectivityManager: ConnectivityManager): String {
   if (context == null) {
     return NetworkState.moblieOther.toString()
   }
-
-  //在这里权限检查
-  val ret =  ContextCompat.checkSelfPermission(context,android.Manifest.permission.READ_PHONE_STATE)
-  if (ret == PackageManager.PERMISSION_DENIED) {
+  
+  val networkInfo = connectivityManager.activeNetworkInfo
+  if (networkInfo == null) {
     return NetworkState.moblieOther.toString()
   }
-
-  val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
   val moblie2G_types = arrayOf(
           TelephonyManager.NETWORK_TYPE_1xRTT,
           TelephonyManager.NETWORK_TYPE_EDGE,
@@ -144,7 +141,7 @@ private  fun getMobileNetworkType(context: Context): String {
           TelephonyManager.NETWORK_TYPE_CDMA,
           TelephonyManager.NETWORK_TYPE_IDEN
   )
-  if (telephonyManager.dataNetworkType in moblie2G_types) {
+  if (networkInfo.subtype in moblie2G_types) {
     return NetworkState.moblie2G.toString()
   }
   val moblie3G_types = arrayOf(
@@ -158,13 +155,13 @@ private  fun getMobileNetworkType(context: Context): String {
           TelephonyManager.NETWORK_TYPE_EHRPD,
           TelephonyManager.NETWORK_TYPE_HSPAP
   )
-  if (telephonyManager.dataNetworkType in moblie3G_types) {
+  if (networkInfo.subtype in moblie3G_types) {
     return NetworkState.moblie3G.toString()
   }
-  if (telephonyManager.dataNetworkType == TelephonyManager.NETWORK_TYPE_LTE) {
+  if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_LTE) {
     return NetworkState.moblie4G.toString()
   }
-  if (telephonyManager.dataNetworkType == TelephonyManager.NETWORK_TYPE_NR) {
+  if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_NR) {
     return NetworkState.moblie5G.toString()
   }
   return NetworkState.moblieOther.toString()

--- a/android/src/main/kotlin/com/aledev/network_type_reachability/NetworkTypeReachabilityPlugin.kt
+++ b/android/src/main/kotlin/com/aledev/network_type_reachability/NetworkTypeReachabilityPlugin.kt
@@ -127,24 +127,24 @@ private  fun getNetworkState(connectivityManager: ConnectivityManager, context: 
 @RequiresApi(Build.VERSION_CODES.N)
 private  fun getMobileNetworkType(context: Context, connectivityManager: ConnectivityManager): String {
   if (context == null) {
-    return NetworkState.moblieOther.toString()
+    return NetworkState.mobileOther.toString()
   }
   
   val networkInfo = connectivityManager.activeNetworkInfo
   if (networkInfo == null) {
-    return NetworkState.moblieOther.toString()
+    return NetworkState.mobileOther.toString()
   }
-  val moblie2G_types = arrayOf(
+  val mobile2G_types = arrayOf(
           TelephonyManager.NETWORK_TYPE_1xRTT,
           TelephonyManager.NETWORK_TYPE_EDGE,
           TelephonyManager.NETWORK_TYPE_GPRS,
           TelephonyManager.NETWORK_TYPE_CDMA,
           TelephonyManager.NETWORK_TYPE_IDEN
   )
-  if (networkInfo.subtype in moblie2G_types) {
-    return NetworkState.moblie2G.toString()
+  if (networkInfo.subtype in mobile2G_types) {
+    return NetworkState.mobile2G.toString()
   }
-  val moblie3G_types = arrayOf(
+  val mobile3G_types = arrayOf(
           TelephonyManager.NETWORK_TYPE_UMTS,
           TelephonyManager.NETWORK_TYPE_EVDO_0,
           TelephonyManager.NETWORK_TYPE_EVDO_A,
@@ -155,25 +155,25 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
           TelephonyManager.NETWORK_TYPE_EHRPD,
           TelephonyManager.NETWORK_TYPE_HSPAP
   )
-  if (networkInfo.subtype in moblie3G_types) {
-    return NetworkState.moblie3G.toString()
+  if (networkInfo.subtype in mobile3G_types) {
+    return NetworkState.mobile3G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_LTE) {
-    return NetworkState.moblie4G.toString()
+    return NetworkState.mobile4G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_NR) {
-    return NetworkState.moblie5G.toString()
+    return NetworkState.mobile5G.toString()
   }
-  return NetworkState.moblieOther.toString()
+  return NetworkState.mobileOther.toString()
 }
 
 
 private enum class NetworkState {
   unReachable,
-  moblie2G,
-  moblie3G,
+  mobile2G,
+  mobile3G,
   wifi,
-  moblie4G,
-  moblie5G,
-  moblieOther
+  mobile4G,
+  mobile5G,
+  mobileOther
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,9 +33,6 @@ class _MyAppState extends State<MyApp> {
   }
 
   _listenNetworkStatus() async {
-    if (Platform.isAndroid) {
-      await NetworkTypeReachability().getPermisionsAndroid;
-    }
     subscriptionNetworkType =
         NetworkTypeReachability().onNetworkStateChanged.listen((event) {
       setState(() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'dart:async';
 
@@ -57,9 +55,6 @@ class _MyAppState extends State<MyApp> {
   }
 
   _getCurrentNetworkStatus() async {
-    if (Platform.isAndroid) {
-      await NetworkTypeReachability().getPermisionsAndroid;
-    }
     NetworkStatus status =
         await NetworkTypeReachability().currentNetworkStatus();
     switch (status) {
@@ -69,13 +64,13 @@ class _MyAppState extends State<MyApp> {
       //wifi
       case NetworkStatus.mobile2G:
       //2g
-      case NetworkStatus.moblie3G:
+      case NetworkStatus.mobile3G:
       //3g
-      case NetworkStatus.moblie4G:
+      case NetworkStatus.mobile4G:
       //4g
-      case NetworkStatus.moblie5G:
+      case NetworkStatus.mobile5G:
       //5h
-      case NetworkStatus.otherMoblie:
+      case NetworkStatus.otherMobile:
       //other
     }
     setState(() {
@@ -275,10 +270,10 @@ class _MyAppState extends State<MyApp> {
     // case NetworkStatus.unreachable:
     // case NetworkStatus.wifi:
     // case NetworkStatus.mobile2G:
-    // case NetworkStatus.moblie3G:
-    // case NetworkStatus.moblie4G:
-    // case NetworkStatus.moblie5G:
-    // case NetworkStatus.otherMoblie:
+    // case NetworkStatus.mobile3G:
+    // case NetworkStatus.mobile4G:
+    // case NetworkStatus.mobile5G:
+    // case NetworkStatus.othermobile:
     switch (data) {
       case 'Unknown':
         return Colors.yellow.shade100;

--- a/ios/Classes/SwiftNetworkTypeReachabilityPlugin.swift
+++ b/ios/Classes/SwiftNetworkTypeReachabilityPlugin.swift
@@ -90,15 +90,15 @@ extension SwiftNetworkTypeReachabilityPlugin: FlutterStreamHandler {
                     CTRadioAccessTechnologyCDMAEVDORevA,
                     CTRadioAccessTechnologyCDMAEVDORevB,
                     CTRadioAccessTechnologyeHRPD].contains(access) {
-                    return NetworkStatus.moblie3G.value
+                    return NetworkStatus.mobile3G.value
                 }
 
                 if [CTRadioAccessTechnologyLTE].contains(access) {
-                    return NetworkStatus.moblie4G.value
+                    return NetworkStatus.mobile4G.value
                 }
                 if #available(iOS 14.1, *), [CTRadioAccessTechnologyNRNSA,
                                              CTRadioAccessTechnologyNR].contains(access) {
-                    return NetworkStatus.moblie5G.value
+                    return NetworkStatus.mobile5G.value
                 }
                 return NetworkStatus.other.value
 
@@ -113,11 +113,11 @@ extension SwiftNetworkTypeReachabilityPlugin: FlutterStreamHandler {
     enum NetworkStatus: String {
         case unreach = "unreach"
         case mobile2G = "mobile2G"
-        case moblie3G = "moblie3G"
+        case mobile3G = "mobile3G"
         case wifi = "wifi"
-        case moblie4G = "moblie4G"
-        case moblie5G = "moblie5G"
-        case other = "moblieOther"
+        case mobile4G = "mobile4G"
+        case mobile5G = "mobile5G"
+        case other = "mobileOther"
         var value: String{
             return "\(self.rawValue)"
         }

--- a/lib/network_type_reachability.dart
+++ b/lib/network_type_reachability.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:flutter/services.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 import 'package:dart_ping/dart_ping.dart';
 import 'package:dart_ping_ios/dart_ping_ios.dart';
@@ -11,10 +10,10 @@ enum NetworkStatus {
   unreachable,
   wifi,
   mobile2G,
-  moblie3G,
-  moblie4G,
-  moblie5G,
-  otherMoblie
+  mobile3G,
+  mobile4G,
+  mobile5G,
+  otherMobile
 }
 
 enum InternetStatusConnection {
@@ -62,16 +61,16 @@ class NetworkTypeReachability {
         return NetworkStatus.unreachable;
       case "mobile2G":
         return NetworkStatus.mobile2G;
-      case "moblie3G":
-        return NetworkStatus.moblie3G;
+      case "mobile3G":
+        return NetworkStatus.mobile3G;
       case "wifi":
         return NetworkStatus.wifi;
-      case "moblie4G":
-        return NetworkStatus.moblie4G;
-      case "moblie5G":
-        return NetworkStatus.moblie5G;
-      case "moblieOther":
-        return NetworkStatus.otherMoblie;
+      case "mobile4G":
+        return NetworkStatus.mobile4G;
+      case "mobile5G":
+        return NetworkStatus.mobile5G;
+      case "mobileOther":
+        return NetworkStatus.otherMobile;
       default:
         return NetworkStatus.unreachable;
     }
@@ -135,7 +134,9 @@ class NetworkTypeReachability {
           globalStatusConnection = statusConnection;
           yield globalStatusConnection;
         }
-      } catch (error) {}
+      } catch (error) {
+        log(error);
+      }
       await Future.delayed(const Duration(seconds: 5));
     }
   }

--- a/lib/network_type_reachability.dart
+++ b/lib/network_type_reachability.dart
@@ -76,10 +76,6 @@ class NetworkTypeReachability {
     }
   }
 
-  /// required to distinguish mobile internet from 2g,3g,4g,5g
-  Future<PermissionStatus> get getPermisionsAndroid async =>
-      await Permission.phone.request();
-
   /// performs a sending and receiving of packets to an internet page,
   /// if the number of packets sent is equal to the number of packets received
   /// then if there is a good internet connection


### PR DESCRIPTION
- I have made some changes in the plugin implementation to avoid having to manage permissions.
- I have fixed some spelling mistakes.
- I have deleted the method 'getPermisionsAndroid' because it is no longer needed.